### PR TITLE
feat: 공통 응답 DTO 적용

### DIFF
--- a/src/main/java/com/roome/admin/roomeadminbe/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/admin/controller/AdminController.java
@@ -1,10 +1,15 @@
 package com.roome.admin.roomeadminbe.domain.admin.controller;
 
+import static com.roome.admin.roomeadminbe.domain.common.dto.response.CommonResponse.ofDataWithHttpStatus;
+
+import com.roome.admin.roomeadminbe.domain.common.dto.response.CommonResponse;
 import com.roome.admin.roomeadminbe.domain.admin.dto.request.UpdateAdminInfoRequest;
 import com.roome.admin.roomeadminbe.domain.admin.dto.request.UpdatePasswordRequest;
 import com.roome.admin.roomeadminbe.domain.admin.dto.response.ReadAdminInfoResponse;
 import com.roome.admin.roomeadminbe.domain.admin.service.AdminService;
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -19,20 +24,20 @@ public class AdminController {
 	private final AdminService adminService;
 
 	@GetMapping
-	public ResponseEntity<ReadAdminInfoResponse> readInfo(@AuthenticationPrincipal UserDetails userDetails) {
+	public ResponseEntity<CommonResponse<ReadAdminInfoResponse>> readInfo(@AuthenticationPrincipal UserDetails userDetails) {
 		ReadAdminInfoResponse readAdminInfo = adminService.readInfo(userDetails.getUsername());
-		return ResponseEntity.ok().body(readAdminInfo);
-	}
+		return ofDataWithHttpStatus(readAdminInfo, HttpStatus.OK);
+	}	
 
 	@PatchMapping
-	public ResponseEntity<Void> updateInfo(@AuthenticationPrincipal UserDetails userDetails, @RequestBody @Validated UpdateAdminInfoRequest updateAdminInfoRequest) {
+	public ResponseEntity<CommonResponse<String>> updateInfo(@AuthenticationPrincipal UserDetails userDetails, @RequestBody @Validated UpdateAdminInfoRequest updateAdminInfoRequest) {
 		adminService.updateInfo(userDetails.getUsername(), updateAdminInfoRequest);
-		return ResponseEntity.ok().build();
+		return ofDataWithHttpStatus("사용자 정보 변경 완료", HttpStatus.OK);
 	}
 
 	@PutMapping("/password")
-	public ResponseEntity<Void> updatePassword(@AuthenticationPrincipal UserDetails userDetails, @RequestBody @Validated UpdatePasswordRequest updatePasswordRequest) {
+	public ResponseEntity<CommonResponse<String>> updatePassword(@AuthenticationPrincipal UserDetails userDetails, @RequestBody @Validated UpdatePasswordRequest updatePasswordRequest) {
 		adminService.updatePassword(userDetails.getUsername(), updatePasswordRequest);
-		return ResponseEntity.ok().build();
+		return ofDataWithHttpStatus("비밀번호 변경 완료", HttpStatus.OK);
 	}
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/auth/controller/AuthController.java
@@ -1,5 +1,8 @@
 package com.roome.admin.roomeadminbe.domain.auth.controller;
 
+import static com.roome.admin.roomeadminbe.domain.common.dto.response.CommonResponse.ofDataWithHttpStatus;
+
+import com.roome.admin.roomeadminbe.domain.common.dto.response.CommonResponse;
 import com.roome.admin.roomeadminbe.domain.auth.dto.TokenResponseDto;
 import com.roome.admin.roomeadminbe.domain.auth.dto.request.LoginRequest;
 import com.roome.admin.roomeadminbe.domain.auth.dto.request.SendTempPasswordRequest;
@@ -29,9 +32,9 @@ public class AuthController {
 
     // 임시 password 발급 (첫 로그인)
     @PostMapping("/password")
-    public ResponseEntity<Void> sendTempPassword(@RequestBody SendTempPasswordRequest sendTempPasswordRequest) {
+    public ResponseEntity<CommonResponse<String>> sendTempPassword(@RequestBody SendTempPasswordRequest sendTempPasswordRequest) {
         authService.sendTempPassword(sendTempPasswordRequest);
-        return ResponseEntity.ok().build();
+        return ofDataWithHttpStatus("임시 비밀번호 발급 완료", HttpStatus.OK);
     }
 
     // 로그인
@@ -57,8 +60,8 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<Void> logout(HttpServletRequest request, HttpServletResponse response) {
+    public ResponseEntity<CommonResponse<String>> logout(HttpServletRequest request, HttpServletResponse response) {
         authService.logout(request, response);
-        return ResponseEntity.noContent().build();
+        return ofDataWithHttpStatus("로그아웃 완료", HttpStatus.OK);
     }
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/common/dto/response/CommonResponse.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/common/dto/response/CommonResponse.java
@@ -1,0 +1,25 @@
+package com.roome.admin.roomeadminbe.domain.common.dto.response;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CommonResponse<T> {
+
+    T data;
+
+    public static <T> CommonResponse<T> ofData(T data) {
+        return CommonResponse.<T>builder()
+            .data(data)
+            .build();
+    }
+
+    public static <T> ResponseEntity<CommonResponse<T>> ofDataWithHttpStatus(T data, HttpStatus httpStatus) {
+        CommonResponse<T> commonResponse = CommonResponse.ofData(data);
+        return ResponseEntity.status(httpStatus).body(commonResponse);
+    }
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/superadmin/controller/SuperAdminController.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/superadmin/controller/SuperAdminController.java
@@ -1,10 +1,15 @@
 package com.roome.admin.roomeadminbe.domain.superadmin.controller;
 
+import static com.roome.admin.roomeadminbe.domain.common.dto.response.CommonResponse.ofDataWithHttpStatus;
+
+import com.roome.admin.roomeadminbe.domain.common.dto.response.CommonResponse;
 import com.roome.admin.roomeadminbe.domain.admin.dto.request.AdminListRequest;
 import com.roome.admin.roomeadminbe.domain.admin.dto.response.AdminListResponse;
 import com.roome.admin.roomeadminbe.domain.superadmin.dto.request.InviteAdminRequest;
 import com.roome.admin.roomeadminbe.domain.superadmin.service.SuperAdminService;
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -21,22 +26,22 @@ public class SuperAdminController {
 
     @PreAuthorize("hasRole('SUPER_ADMIN')")
     @PostMapping("/invite")
-    public ResponseEntity<Void> inviteAdmin(@AuthenticationPrincipal UserDetails userDetails, @RequestBody @Validated InviteAdminRequest inviteAdminRequestDto) {
+    public ResponseEntity<CommonResponse<String>> inviteAdmin(@AuthenticationPrincipal UserDetails userDetails, @RequestBody @Validated InviteAdminRequest inviteAdminRequestDto) {
         superAdminService.inviteAdmin(inviteAdminRequestDto);
-        return ResponseEntity.ok().build();
+        return ofDataWithHttpStatus("관리자 초대 완료", HttpStatus.OK);
     }
 
     @PreAuthorize("hasRole('SUPER_ADMIN')")
     @GetMapping("/admins")
-    public ResponseEntity<AdminListResponse> getAdminList(@AuthenticationPrincipal UserDetails userDetails, @ModelAttribute AdminListRequest adminListRequest) {
+    public ResponseEntity<CommonResponse<AdminListResponse>> getAdminList(@AuthenticationPrincipal UserDetails userDetails, @ModelAttribute AdminListRequest adminListRequest) {
         AdminListResponse adminListResponse = superAdminService.getAdminList(adminListRequest);
-        return ResponseEntity.ok().body(adminListResponse);
+        return ofDataWithHttpStatus(adminListResponse, HttpStatus.OK);
     }
 
     @PreAuthorize("hasRole('SUPER_ADMIN')")
     @PatchMapping("/admins/{adminId}/delete")
-    public ResponseEntity<Void> deleteAdminRole(@AuthenticationPrincipal UserDetails userDetails, @PathVariable("adminId") Long adminId) {
+    public ResponseEntity<CommonResponse<String>> deleteAdminRole(@AuthenticationPrincipal UserDetails userDetails, @PathVariable("adminId") Long adminId) {
         superAdminService.deleteAdminRole(adminId);
-        return ResponseEntity.ok().build();
+        return ofDataWithHttpStatus("관리자 권한 삭제 완료", HttpStatus.OK);
     }
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/global/security/jwt/controller/TokenController.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/global/security/jwt/controller/TokenController.java
@@ -1,9 +1,14 @@
 package com.roome.admin.roomeadminbe.global.security.jwt.controller;
 
+import static com.roome.admin.roomeadminbe.domain.common.dto.response.CommonResponse.ofDataWithHttpStatus;
+
+import com.roome.admin.roomeadminbe.domain.common.dto.response.CommonResponse;
 import com.roome.admin.roomeadminbe.global.security.jwt.service.TokenService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -15,8 +20,8 @@ public class TokenController {
 	private final TokenService tokenService;
 
 	@PostMapping("/refresh")
-	public ResponseEntity<Void> refreshAccessToken(HttpServletRequest request, HttpServletResponse response) {
+	public ResponseEntity<CommonResponse<String>> refreshAccessToken(HttpServletRequest request, HttpServletResponse response) {
 		tokenService.refreshAccessToken(request, response);
-		return ResponseEntity.ok().build();
+		return ofDataWithHttpStatus("액세스 토큰 갱신 완료", HttpStatus.OK);
 	}
 }


### PR DESCRIPTION
## 📌 PR 제목 (예: `feat: 회원가입 기능 추가`)

feat: 공통 응답 DTO 적용

### ✅ PR 설명

API 응답의 일관성을 유지하고 클라이언트에서의 처리를 용이하게 하기 위해 공통 응답 DTO를 도입하고, 기존 API에 적용합니다.

### 🏗 작업 내용

- [x] `CommonResponse` DTO 생성
- [x] Admin, Auth, SuperAdmin, Token 관련 API의 반환 타입을 `CommonResponse`로 통일
- [ ] 테스트는 진행하지 않음

### 📸 테스트 결과 (선택)

> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

(첨부 파일 없음)

### 🔗 관련 이슈 (선택)

> 관련된 Issue가 있다면 `#이슈번호` 형식으로 작성해주세요.

(관련 이슈 없음)

### 🚨 참고 사항 (선택)

> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.

(특이사항 없음)